### PR TITLE
Add clips_to_bounds for viewport-aware ScrollView rendering

### DIFF
--- a/examples/scroll_large.rs
+++ b/examples/scroll_large.rs
@@ -1,0 +1,80 @@
+use pelican::graphics::Rectangle;
+use pelican::ui::{View, Window, Color};
+use pelican::ui::{ApplicationMain, ApplicationDelegate};
+use pelican::ui::{ViewController, ViewControllerBehavior};
+use pelican::ui::ScrollView;
+use pelican::ui::button::Button;
+
+struct ExampleViewController {}
+impl ViewControllerBehavior for ExampleViewController {
+    fn view_did_load(&self, view: View) {
+        let frame = Rectangle::new(0, 0, 600, 400);
+        let scroll_view = ScrollView::new(frame);
+
+        // 5000x5000 content — would be a huge texture without clips_to_bounds
+        let content_view = View::new(Rectangle::new(0, 0, 5000, 5000));
+        content_view.set_background_color(Color::new(30, 30, 30, 255));
+
+        // Grid of colored tiles so scrolling is visually obvious
+        let colors = [
+            Color::red(),
+            Color::green(),
+            Color::blue(),
+            Color::new(255, 165, 0, 255), // orange
+            Color::new(128, 0, 128, 255), // purple
+            Color::new(0, 128, 128, 255), // teal
+        ];
+
+        let tile_size = 200;
+        let cols = 5000 / tile_size;
+        let rows = 5000 / tile_size;
+        let mut color_idx = 0;
+
+        for row in 0..rows {
+            for col in 0..cols {
+                let x = (col * tile_size) as i32;
+                let y = (row * tile_size) as i32;
+
+                let tile = View::new(Rectangle::new(
+                    x + 2, y + 2,
+                    tile_size as u32 - 4, tile_size as u32 - 4,
+                ));
+                tile.set_background_color(colors[color_idx % colors.len()].clone());
+                content_view.add_subview(tile);
+
+                color_idx += 1;
+            }
+        }
+
+        // A few buttons scattered around to test interaction
+        for (i, (bx, by)) in [(100, 100), (2500, 2500), (4800, 4800)].iter().enumerate() {
+            let label = format!("Button {}", i + 1);
+            let button = Button::new(
+                Rectangle::new(*bx, *by, 120, 40),
+                &label,
+                move || { println!("Button {} tapped", i + 1); },
+            );
+            button.view.set_background_color(Color::white());
+            content_view.add_subview(button.view);
+        }
+
+        scroll_view.set_content_view(content_view);
+        view.add_subview(scroll_view.view);
+    }
+}
+
+struct AppDelegate {}
+impl ApplicationDelegate for AppDelegate {
+    fn application_did_finish_launching(&self) {
+        let frame = Rectangle::new(200, 200, 600, 400);
+        let view_controller = ViewController::new(ExampleViewController {});
+        let window = Window::new("Large scroll (5000x5000)", frame, view_controller);
+        window.make_key_and_visible();
+    }
+}
+
+pub fn main() -> Result<(), String> {
+    let application_main = ApplicationMain::new(AppDelegate {});
+    application_main.launch();
+    Ok(())
+}

--- a/src/graphics/rectangle.rs
+++ b/src/graphics/rectangle.rs
@@ -51,6 +51,13 @@ impl Rectangle<i32, u32> {
         self.origin.x
     }
 
+    pub fn intersects(&self, other: &Rectangle<i32, u32>) -> bool {
+        self.left() < other.right()
+            && self.right() > other.left()
+            && self.top() < other.bottom()
+            && self.bottom() > other.top()
+    }
+
     pub fn width(&self) -> u32 {
         self.size.width
     }

--- a/src/ui/render.rs
+++ b/src/ui/render.rs
@@ -46,9 +46,24 @@ fn draw_view(view: &View, behavior: &WindowBehavior, context: &Context) {
 
             // TODO: lazily recreate layer if mismatch contexts
             if inner_view.layer.as_ref().is_none() {
-                let size = inner_view.frame.size.clone();
+                let size = if inner_view.clips_to_bounds {
+                    inner_view.bounds.size.clone()
+                } else {
+                    inner_view.frame.size.clone()
+                };
                 let layer = Layer::new(context.clone(), size, Box::new(view.clone()));
                 inner_view.layer = Some(layer);
+            }
+
+            // Recreate layer if clips_to_bounds and bounds size changed
+            if inner_view.clips_to_bounds {
+                if let Some(ref layer) = inner_view.layer {
+                    if *layer.size() != inner_view.bounds.size {
+                        let size = inner_view.bounds.size.clone();
+                        let layer = Layer::new(context.clone(), size, Box::new(view.clone()));
+                        inner_view.layer = Some(layer);
+                    }
+                }
             }
 
             let layer = inner_view.layer.as_mut().unwrap();
@@ -71,25 +86,52 @@ fn draw_view(view: &View, behavior: &WindowBehavior, context: &Context) {
 
     let inner_view = view.inner_self.borrow();
     let layer = inner_view.layer.as_ref().unwrap();
+    let clips = inner_view.clips_to_bounds;
+    let bounds = view.bounds();
 
     for subview in view.subviews().iter() {
-        // redraw the subview (if it needs it!)
-        draw_view(subview, behavior, context);
-
         if subview.is_hidden() {
             continue;
         }
 
+        // Skip subviews entirely outside the visible bounds
+        if clips {
+            let visible_rect = Rectangle::new(
+                bounds.origin.x,
+                bounds.origin.y,
+                bounds.size.width,
+                bounds.size.height,
+            );
+            let sub_frame = subview.frame();
+            if !visible_rect.intersects(&sub_frame) {
+                continue;
+            }
+        }
+
+        // redraw the subview (if it needs it!)
+        draw_view(subview, behavior, context);
+
         let sub_inner_view = subview.inner_self.borrow();
-        let subview_layer = sub_inner_view.layer.as_ref().unwrap();
+        let subview_layer = match sub_inner_view.layer.as_ref() {
+            Some(l) => l,
+            None => continue,
+        };
 
         let frame = subview.frame();
 
+        // For clips_to_bounds children, the texture is bounds-sized not
+        // frame-sized, so use bounds.size for the destination dimensions.
+        let (dest_width, dest_height) = if sub_inner_view.clips_to_bounds {
+            (sub_inner_view.bounds.size.width, sub_inner_view.bounds.size.height)
+        } else {
+            (frame.size.width, frame.size.height)
+        };
+
         let frame_relative_to_superview_bounds = Rectangle::new(
-            frame.origin.x - view.bounds().origin.x,
-            frame.origin.y - view.bounds().origin.y,
-            frame.size.width,
-            frame.size.height,
+            frame.origin.x - bounds.origin.x,
+            frame.origin.y - bounds.origin.y,
+            dest_width,
+            dest_height,
         );
 
         layer.draw_child_layer(subview_layer, &frame_relative_to_superview_bounds);

--- a/src/ui/view/scroll_view.rs
+++ b/src/ui/view/scroll_view.rs
@@ -22,6 +22,7 @@ custom_view!(
 
             let content_view = View::new(Rectangle::new(0, 0, 0, 0));
             content_view.set_background_color(Color::clear());
+            content_view.set_clips_to_bounds(true);
 
             let scroll_view = Self::new_all(frame);
             scroll_view.view.set_background_color(Color::clear());
@@ -146,6 +147,15 @@ custom_view!(
         fn update_content_size(&self, size: Size<u32>) {
             let inner_content_view = self.inner_content_view();
             inner_content_view.set_frame(Rectangle::new(0, 0, size.width, size.height));
+
+            // set_frame resets bounds.size to frame.size. Restore viewport-
+            // sized bounds so the clips_to_bounds layer stays viewport-sized.
+            let viewport_size = self.view.frame().size.clone();
+            inner_content_view.set_bounds(Rectangle::new(
+                0, 0,
+                viewport_size.width,
+                viewport_size.height,
+            ));
 
             self.vertical_scroll_bar().update_scroll_handle();
             self.horizontal_scroll_bar().update_scroll_handle();

--- a/src/ui/view/view.rs
+++ b/src/ui/view/view.rs
@@ -61,7 +61,8 @@ impl View {
             subviews: Vec::new(),
             gesture_recognizers: Vec::new(),
             hidden: false,
-            user_interaction_enabled: true
+            user_interaction_enabled: true,
+            clips_to_bounds: false
         };
 
         let view = View {
@@ -207,6 +208,14 @@ impl View {
             let mut inner_self = self.inner_self.borrow_mut();
             inner_self.user_interaction_enabled = enabled;
         }
+    }
+
+    pub fn clips_to_bounds(&self) -> bool {
+        self.inner_self.borrow().clips_to_bounds
+    }
+
+    pub fn set_clips_to_bounds(&self, value: bool) {
+        self.inner_self.borrow_mut().clips_to_bounds = value;
     }
 
     pub fn set_hidden(&self, value: bool) {

--- a/src/ui/view/view_inner.rs
+++ b/src/ui/view/view_inner.rs
@@ -73,5 +73,11 @@ pub(crate) struct ViewInner {
 
     /// Whether the view accepts user input or not. E.g. touches_began will not
     /// be called if this is `false`.
-    pub user_interaction_enabled: bool
+    pub user_interaction_enabled: bool,
+
+    /// When true, the layer is created at `bounds.size` instead of
+    /// `frame.size`, and subviews outside the visible bounds are not rendered.
+    /// Used by ScrollView's inner content view to avoid creating a texture the
+    /// full content size.
+    pub clips_to_bounds: bool
 }


### PR DESCRIPTION
## Summary
- Adds a `clips_to_bounds` property to `View`. When enabled, the view's GPU texture is created at `bounds.size` (viewport) instead of `frame.size` (full content), and subviews outside the visible bounds are culled during rendering.
- ScrollView's inner content view enables `clips_to_bounds`, so large scrollable content (e.g. 5000x5000) no longer allocates a massive texture — only a viewport-sized one.
- Subviews are loaded/unloaded on demand as they scroll into and out of view.
- Includes a `scroll_large` example with a 5000x5000 grid to verify the behaviour.

## Test plan
- [x] `cargo test` — all 195 tests pass
- [x] `cargo run --example scroll` — existing scroll example still works
- [x] `cargo run --example scroll_large` — 5000x5000 content renders without texture size issues, scrolling and button interaction work

🤖 Generated with [Claude Code](https://claude.com/claude-code)