### PR TITLE
Add Deref/Into<View> for widgets and range-based set_attribute

### DIFF
--- a/examples/image.rs
+++ b/examples/image.rs
@@ -15,9 +15,9 @@ impl ViewControllerBehavior for ExampleViewController {
         let always1tree = Image::new("always1tree.png");
         let tree3 = ImageView::new(always1tree, Point::new(700, 10));
 
-        view.add_subview(tree.view);
-        view.add_subview(tree2.view);
-        view.add_subview(tree3.view);
+        view.add_subview(tree);
+        view.add_subview(tree2);
+        view.add_subview(tree3);
     }
 }
 

--- a/examples/label.rs
+++ b/examples/label.rs
@@ -4,7 +4,6 @@ use pelican::ui::{ApplicationMain, ApplicationDelegate};
 use pelican::ui::{ViewController, ViewControllerBehavior};
 use pelican::text::{HorizontalAlignment, VerticalAlignment};
 use pelican::text::attributed_string::AttributedString;
-use pelican::text::attributed_string::Key;
 use pelican::text::attributed_string::Attribute;
 
 static PADDING: i32 = 10;
@@ -20,16 +19,14 @@ impl ViewControllerBehavior for ExampleViewController {
         let label = Label::new(frame, text.clone());
         label.set_text_alignment(HorizontalAlignment::Center);
         label.set_vertical_alignment(VerticalAlignment::Middle);
-        label.view.set_background_color(Color::gray());
-        view.add_subview(label.view.clone());
+        label.set_background_color(Color::gray());
+        view.add_subview(label.clone());
 
         let attributed_string = AttributedString::new(text);
         let red = Color::red().to_graphics_color();
 
         // highlight the word "fox"
-        attributed_string.set_attribute_for(16, Key::Color, Attribute::Color { color: red });
-        attributed_string.set_attribute_for(17, Key::Color, Attribute::Color { color: red });
-        attributed_string.set_attribute_for(18, Key::Color, Attribute::Color { color: red });
+        attributed_string.set_attribute(16..19, Attribute::Color { color: red });
 
         label.set_attributed_text(attributed_string);
 
@@ -38,41 +35,41 @@ impl ViewControllerBehavior for ExampleViewController {
         let button = Button::new(frame, "Center", move || {
             label_clone.set_text_alignment(HorizontalAlignment::Center);
         });
-        view.add_subview(button.view);
+        view.add_subview(button);
 
         let label_clone = label.clone();
         let frame = Rectangle::new(PADDING, BUTTON_START + ((PADDING + BUTTON_HEIGHT as i32) * 1), INNER_WIDTH, BUTTON_HEIGHT);
         let button = Button::new(frame, "Left", move || {
             label_clone.set_text_alignment(HorizontalAlignment::Left);
         });
-        view.add_subview(button.view);
+        view.add_subview(button);
 
         let label_clone = label.clone();
         let frame = Rectangle::new(PADDING, BUTTON_START + ((PADDING + BUTTON_HEIGHT as i32) * 2), INNER_WIDTH, BUTTON_HEIGHT);
         let button = Button::new(frame, "Right", move || {
             label_clone.set_text_alignment(HorizontalAlignment::Right);
         });
-        view.add_subview(button.view);
+        view.add_subview(button);
 
         let label_clone = label.clone();
         let frame = Rectangle::new(PADDING, BUTTON_START + ((PADDING + BUTTON_HEIGHT as i32) * 3), INNER_WIDTH, BUTTON_HEIGHT);
         let button = Button::new(frame, "Top", move || {
             label_clone.set_vertical_alignment(VerticalAlignment::Top);
         });
-        view.add_subview(button.view);
+        view.add_subview(button);
 
         let label_clone = label.clone();
         let frame = Rectangle::new(PADDING, BUTTON_START + ((PADDING + BUTTON_HEIGHT as i32) * 4), INNER_WIDTH, BUTTON_HEIGHT);
         let button = Button::new(frame, "Middle", move || {
             label_clone.set_vertical_alignment(VerticalAlignment::Middle);
         });
-        view.add_subview(button.view);
+        view.add_subview(button);
 
         let frame = Rectangle::new(PADDING, BUTTON_START + ((PADDING + BUTTON_HEIGHT as i32) * 5), INNER_WIDTH, BUTTON_HEIGHT);
         let button = Button::new(frame, "Bottom", move || {
             label.set_vertical_alignment(VerticalAlignment::Bottom);
         });
-        view.add_subview(button.view);
+        view.add_subview(button);
     }
 }
 

--- a/examples/scroll.rs
+++ b/examples/scroll.rs
@@ -24,11 +24,11 @@ impl ViewControllerBehavior for ExampleViewController {
         let button = Button::new(frame, "Button", move || {
             println!("button tapped");
         });
-        button.view.set_background_color(Color::white());
-        content_view.add_subview(button.view);
+        button.set_background_color(Color::white());
+        content_view.add_subview(button);
 
         scroll_view.set_content_view(content_view);
-        view.add_subview(scroll_view.view);
+        view.add_subview(scroll_view);
     }
 }
 

--- a/examples/scroll_large.rs
+++ b/examples/scroll_large.rs
@@ -54,12 +54,12 @@ impl ViewControllerBehavior for ExampleViewController {
                 &label,
                 move || { println!("Button {} tapped", i + 1); },
             );
-            button.view.set_background_color(Color::white());
-            content_view.add_subview(button.view);
+            button.set_background_color(Color::white());
+            content_view.add_subview(button);
         }
 
         scroll_view.set_content_view(content_view);
-        view.add_subview(scroll_view.view);
+        view.add_subview(scroll_view);
     }
 }
 

--- a/examples/text_field.rs
+++ b/examples/text_field.rs
@@ -12,14 +12,14 @@ impl ViewControllerBehavior for ExampleViewController {
         view.add_subview(background.clone());
 
         let text_field = TextField::new(Rectangle::new(10, 10, 180, 36 * 2), "".to_string());
-        text_field.view.set_background_color(Color::white());
-        background.add_subview(text_field.clone().view);
+        text_field.set_background_color(Color::white());
+        background.add_subview(text_field.clone());
 
         text_field.on_text_change(|text_field| {
             println!("text changed: {}", text_field.label().text());
         });
 
-        text_field.view.become_first_responder();
+        text_field.become_first_responder();
     }
 }
 

--- a/examples/ui.rs
+++ b/examples/ui.rs
@@ -9,14 +9,14 @@ impl ViewControllerBehavior for ExampleViewController {
     fn view_did_load(&self, view: View) {
         let image = Image::new("/Users/dan2552/Dropbox/experiments/avian/pelican/test_application/resources/pixels_ruler.png");
         let image_view = ImageView::new(image, Point { x: 0, y: 0 });
-        view.add_subview(image_view.view);
+        view.add_subview(image_view);
 
         let frame = Rectangle::new(0, 0, 200, 200);
         let label = Label::new(frame, String::from("hello rusty world\nhello hello\nmultiline\nThe quick brown fox jumps over the lazy dog"));
         label.set_text_alignment(HorizontalAlignment::Center);
         label.set_vertical_alignment(VerticalAlignment::Middle);
-        label.view.set_background_color(Color::red());
-        view.add_subview(label.view);
+        label.set_background_color(Color::red());
+        view.add_subview(label);
 
         let frame = Rectangle::new(0, 40, 50, 50);
         let red_view = View::new(frame);
@@ -38,7 +38,7 @@ impl ViewControllerBehavior for ExampleViewController {
         view.add_subview(red_view);
         view.add_subview(green_view);
         view.add_subview(blue_view);
-        view.add_subview(button.view);
+        view.add_subview(button);
     }
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -226,6 +226,19 @@ macro_rules! custom_view {
                 Self { view: self.view.clone() }
             }
         }
+
+        impl std::ops::Deref for $view {
+            type Target = $crate::ui::View;
+            fn deref(&self) -> &Self::Target {
+                &self.view
+            }
+        }
+
+        impl From<$view> for $crate::ui::View {
+            fn from(widget: $view) -> Self {
+                widget.view
+            }
+        }
     };
 }
 

--- a/src/text/attributed_string.rs
+++ b/src/text/attributed_string.rs
@@ -28,6 +28,13 @@ impl Attribute {
             _ => panic!("Attribute is not a font")
         }
     }
+
+    pub fn key(&self) -> Key {
+        match self {
+            Attribute::Color { .. } => Key::Color,
+            Attribute::Font { .. } => Key::Font,
+        }
+    }
 }
 
 impl Clone for Attribute {
@@ -164,6 +171,13 @@ impl AttributedString {
         }
 
         attributes[index].insert(key, attribute);
+    }
+
+    pub fn set_attribute(&self, range: std::ops::Range<usize>, attribute: Attribute) {
+        let key = attribute.key();
+        for index in range {
+            self.set_attribute_for(index, key.clone(), attribute.clone());
+        }
     }
 
     pub fn get_attribute_for(&self, index: usize, key: Key) -> Ref<'_, Attribute> {

--- a/src/ui/button.rs
+++ b/src/ui/button.rs
@@ -37,16 +37,16 @@ custom_view!(
             let label_rectangle = Rectangle::new(0, 0, frame.size.width, frame.size.height);
             let label = Label::new(label_rectangle, String::from(text));
             label.set_text_color(DEFAULT_COLOR_NORMAL.clone());
-            label.view.set_user_interaction_enabled(false);
+            label.set_user_interaction_enabled(false);
             label.set_text_alignment(HorizontalAlignment::Center);
             label.set_vertical_alignment(VerticalAlignment::Middle);
-            button.view.add_subview(label.view);
-            button.view.set_background_color(Color::clear());
+            button.add_subview(label);
+            button.set_background_color(Color::clear());
             button
         }
 
         fn label(&self) -> Label {
-            let view = self.view.subviews().get(0).expect("button missing label subview").clone();
+            let view = self.subviews().get(0).expect("button missing label subview").clone();
             Label::from_view(view)
         }
 
@@ -72,7 +72,7 @@ custom_view!(
                 let view = self.view.upgrade().expect("button view was deallocated");
                 let window = touch.window().expect("touch missing window");
 
-                let position = window.view.convert_point_to(&touch.position(), &view);
+                let position = window.convert_point_to(&touch.position(), &view);
 
                 if view.bounds().contains(&position) {
                     (self.action)();
@@ -87,7 +87,7 @@ custom_view!(
                 let view = self.view.upgrade().expect("button view was deallocated");
                 let window = touch.window().expect("touch missing window");
 
-                let position = window.view.convert_point_to(&touch.position(), &view);
+                let position = window.convert_point_to(&touch.position(), &view);
 
                 if view.bounds().contains(&position) {
                     self.set_state(State::Pressed);
@@ -133,7 +133,7 @@ mod tests {
             Box::new(|| {})
         );
 
-        assert_eq!(button.view.frame(), Rectangle::new(0, 0, 100, 100));
+        assert_eq!(button.frame(), Rectangle::new(0, 0, 100, 100));
         assert_eq!(button.label().copy_text(), String::from("Test"));
     }
 }

--- a/src/ui/history/text_field/text_backspace.rs
+++ b/src/ui/history/text_field/text_backspace.rs
@@ -119,7 +119,7 @@ mod tests {
         let mut carats = Vec::new();
         carats.push(CaratSnapshot::new(3, None));
 
-        let mut action = TextBackspace::new(text_field.view.downgrade(), 1, CursorMovement::Character, carats);
+        let mut action = TextBackspace::new(text_field.downgrade(), 1, CursorMovement::Character, carats);
         action.forward();
         assert_eq!(text_field.label().text().string(), "ab");
         assert_eq!(text_field.carat_indexes(), vec![2]);
@@ -135,7 +135,7 @@ mod tests {
         let mut carats = Vec::new();
         carats.push(CaratSnapshot::new(3, None));
 
-        let mut action = TextBackspace::new(text_field.view.downgrade(), 2, CursorMovement::Character, carats);
+        let mut action = TextBackspace::new(text_field.downgrade(), 2, CursorMovement::Character, carats);
         action.forward();
         assert_eq!(text_field.label().text().string(), "a");
         assert_eq!(text_field.carat_indexes(), vec![1]);
@@ -151,7 +151,7 @@ mod tests {
         let mut carats = Vec::new();
         carats.push(CaratSnapshot::new(7, None));
 
-        let mut action = TextBackspace::new(text_field.view.downgrade(), 1, CursorMovement::Word, carats);
+        let mut action = TextBackspace::new(text_field.downgrade(), 1, CursorMovement::Word, carats);
         action.forward();
         assert_eq!(text_field.label().text().string(), "abc ");
         assert_eq!(text_field.carat_indexes(), vec![4]);
@@ -167,7 +167,7 @@ mod tests {
         let mut carats = Vec::new();
         carats.push(CaratSnapshot::new(7, None));
 
-        let mut action = TextBackspace::new(text_field.view.downgrade(), 1, CursorMovement::Line, carats);
+        let mut action = TextBackspace::new(text_field.downgrade(), 1, CursorMovement::Line, carats);
         action.forward();
         assert_eq!(text_field.label().text().string(), "");
         assert_eq!(text_field.carat_indexes(), vec![0]);
@@ -184,7 +184,7 @@ mod tests {
         carats.push(CaratSnapshot::new(1, None));
         carats.push(CaratSnapshot::new(3, None));
 
-        let mut action = TextBackspace::new(text_field.view.downgrade(), 1, CursorMovement::Character, carats);
+        let mut action = TextBackspace::new(text_field.downgrade(), 1, CursorMovement::Character, carats);
         action.forward();
         assert_eq!(text_field.label().text().string(), "b");
         assert_eq!(text_field.carat_indexes(), vec![0, 1]);
@@ -201,7 +201,7 @@ mod tests {
         carats.push(CaratSnapshot::new(1, None));
         carats.push(CaratSnapshot::new(3, None));
 
-        let mut action = TextBackspace::new(text_field.view.downgrade(), 1, CursorMovement::Character, carats);
+        let mut action = TextBackspace::new(text_field.downgrade(), 1, CursorMovement::Character, carats);
         action.forward();
         assert_eq!(text_field.label().text().string(), "b");
         assert_eq!(text_field.carat_indexes(), vec![0, 1]);
@@ -218,7 +218,7 @@ mod tests {
         carats.push(CaratSnapshot::new(3, None));
         carats.push(CaratSnapshot::new(7, None));
 
-        let mut action = TextBackspace::new(text_field.view.downgrade(), 1, CursorMovement::Word, carats);
+        let mut action = TextBackspace::new(text_field.downgrade(), 1, CursorMovement::Word, carats);
         action.forward();
         assert_eq!(text_field.label().text().string(), " ");
         assert_eq!(text_field.carat_indexes(), vec![0, 1]);
@@ -235,7 +235,7 @@ mod tests {
         carats.push(CaratSnapshot::new(3, None));
         carats.push(CaratSnapshot::new(7, None));
 
-        let mut action = TextBackspace::new(text_field.view.downgrade(), 1, CursorMovement::Line, carats);
+        let mut action = TextBackspace::new(text_field.downgrade(), 1, CursorMovement::Line, carats);
         action.forward();
         assert_eq!(text_field.label().text().string(), "");
         assert_eq!(text_field.carat_indexes(), vec![0, 0]);
@@ -251,7 +251,7 @@ mod tests {
         let mut carats = Vec::new();
         carats.push(CaratSnapshot::new(0, Some(0..3)));
 
-        let mut action = TextBackspace::new(text_field.view.downgrade(), 1, CursorMovement::Character, carats);
+        let mut action = TextBackspace::new(text_field.downgrade(), 1, CursorMovement::Character, carats);
         action.forward();
         assert_eq!(text_field.label().text().string(), " def");
         let carats = text_field.carat_snapshots();
@@ -277,7 +277,7 @@ mod tests {
         let mut carats = Vec::new();
         carats.push(CaratSnapshot::new(3, Some(1..3)));
 
-        let mut action = TextBackspace::new(text_field.view.downgrade(), 1, CursorMovement::Word, carats);
+        let mut action = TextBackspace::new(text_field.downgrade(), 1, CursorMovement::Word, carats);
         action.forward();
         assert_eq!(text_field.label().text().string(), "a def");
         let carats = text_field.carat_snapshots();
@@ -303,7 +303,7 @@ mod tests {
         let mut carats = Vec::new();
         carats.push(CaratSnapshot::new(3, Some(1..3)));
 
-        let mut action = TextBackspace::new(text_field.view.downgrade(), 1, CursorMovement::Line, carats);
+        let mut action = TextBackspace::new(text_field.downgrade(), 1, CursorMovement::Line, carats);
         action.forward();
         assert_eq!(text_field.label().text().string(), "a def");
         let carats = text_field.carat_snapshots();
@@ -327,7 +327,7 @@ mod tests {
         carats.push(CaratSnapshot::new(0, Some(0..3)));
         carats.push(CaratSnapshot::new(3, Some(3..6)));
 
-        let mut action = TextBackspace::new(text_field.view.downgrade(), 1, CursorMovement::Character, carats);
+        let mut action = TextBackspace::new(text_field.downgrade(), 1, CursorMovement::Character, carats);
         action.forward();
         assert_eq!(text_field.label().text().string(), "f");
         let carats = text_field.carat_snapshots();
@@ -356,7 +356,7 @@ mod tests {
         carats.push(CaratSnapshot::new(7, None));
 
         let mut action1 = TextBackspace::new(
-            text_field.view.downgrade(),
+            text_field.downgrade(),
             4,
             CursorMovement::Character,
             carats
@@ -366,7 +366,7 @@ mod tests {
         carats.push(CaratSnapshot::new(3, None));
 
         let mut action2 = TextBackspace::new(
-            text_field.view.downgrade(),
+            text_field.downgrade(),
             3,
             CursorMovement::Character,
             carats
@@ -399,7 +399,7 @@ mod tests {
         carats.push(CaratSnapshot::new(7, None));
 
         let mut action1 = TextBackspace::new(
-            text_field.view.downgrade(),
+            text_field.downgrade(),
             4,
             CursorMovement::Character,
             carats
@@ -409,7 +409,7 @@ mod tests {
         carats.push(CaratSnapshot::new(2, None));
 
         let mut action2 = TextBackspace::new(
-            text_field.view.downgrade(),
+            text_field.downgrade(),
             2,
             CursorMovement::Character,
             carats

--- a/src/ui/history/text_field/text_insertion.rs
+++ b/src/ui/history/text_field/text_insertion.rs
@@ -126,7 +126,7 @@ mod tests {
         carats.push(CaratSnapshot::new(0, None));
 
         let mut text_insertion = TextInsertion::new(
-            text_field.view.downgrade(),
+            text_field.downgrade(),
             "Hello".to_string(),
             carats
         );
@@ -147,7 +147,7 @@ mod tests {
         carats.push(CaratSnapshot::new(1, None));
 
         let mut text_insertion = TextInsertion::new(
-            text_field.view.downgrade(),
+            text_field.downgrade(),
             "Hello".to_string(),
             carats
         );
@@ -168,7 +168,7 @@ mod tests {
         carats.push(CaratSnapshot::new(0, None));
 
         let mut text_insertion = TextInsertion::new(
-            text_field.view.downgrade(),
+            text_field.downgrade(),
             "Hello".to_string(),
             carats
         );
@@ -190,7 +190,7 @@ mod tests {
         carats.push(CaratSnapshot::new(1, None));
 
         let mut text_insertion = TextInsertion::new(
-            text_field.view.downgrade(),
+            text_field.downgrade(),
             "Hello".to_string(),
             carats
         );
@@ -226,7 +226,7 @@ mod tests {
         carats.push(CaratSnapshot::new(0, Some(0..2)));
 
         let mut text_insertion = TextInsertion::new(
-            text_field.view.downgrade(),
+            text_field.downgrade(),
             "Hello".to_string(),
             carats
         );
@@ -256,7 +256,7 @@ mod tests {
         carats.push(CaratSnapshot::new(0, None));
 
         let mut text_insertion1 = TextInsertion::new(
-            text_field.view.downgrade(),
+            text_field.downgrade(),
             "Hello".to_string(),
             carats
         );
@@ -265,7 +265,7 @@ mod tests {
         carats.push(CaratSnapshot::new(5, None));
 
         let mut text_insertion2 = TextInsertion::new(
-            text_field.view.downgrade(),
+            text_field.downgrade(),
             " world".to_string(),
             carats
         );
@@ -293,7 +293,7 @@ mod tests {
         carats.push(CaratSnapshot::new(0, None));
 
         let mut text_insertion1 = TextInsertion::new(
-            text_field.view.downgrade(),
+            text_field.downgrade(),
             " world".to_string(),
             carats
         );
@@ -302,7 +302,7 @@ mod tests {
         carats.push(CaratSnapshot::new(0, None));
 
         let mut text_insertion2 = TextInsertion::new(
-            text_field.view.downgrade(),
+            text_field.downgrade(),
             "Hello".to_string(),
             carats
         );

--- a/src/ui/view/label.rs
+++ b/src/ui/view/label.rs
@@ -33,7 +33,7 @@ custom_view!(
                 text_vertical_alignment,
                 RefCell::new(None)
             );
-            label.view.set_background_color(Color::clear());
+            label.set_background_color(Color::clear());
             label
         }
 
@@ -170,14 +170,14 @@ custom_view!(
             let rendering_result = behavior.rendering_result.borrow();
             if let Some(result) = rendering_result.as_ref() {
                 let text_size = result.text_size();
-                let origin = self.view.frame().origin;
+                let origin = self.frame().origin;
                 let frame = Rectangle { origin, size: text_size };
-                self.view.set_frame(frame);
+                self.set_frame(frame);
             }
         }
 
         fn generate_rendering_result(&self) {
-            let inner_self = self.view.inner_self.borrow();
+            let inner_self = self.inner_self.borrow();
             let behavior = self.behavior();
             let attributed_string = behavior.attributed_text.borrow();
 
@@ -189,7 +189,7 @@ custom_view!(
                 render_scale = 1.0;
             }
 
-            let mut whole_text = rendering::WholeText::from(&attributed_string, self.view.frame(), render_scale);
+            let mut whole_text = rendering::WholeText::from(&attributed_string, self.frame(), render_scale);
             whole_text.align_horizontally(behavior.text_alignment.get());
             whole_text.align_vertically(behavior.text_vertical_alignment.get());
 

--- a/src/ui/view/scroll_view.rs
+++ b/src/ui/view/scroll_view.rs
@@ -25,10 +25,10 @@ custom_view!(
             content_view.set_clips_to_bounds(true);
 
             let scroll_view = Self::new_all(frame);
-            scroll_view.view.set_background_color(Color::clear());
-            scroll_view.view.add_subview(content_view);
-            scroll_view.view.add_subview(vertical_scroll_bar.view.clone());
-            scroll_view.view.add_subview(horizontal_scroll_bar.view.clone());
+            scroll_view.set_background_color(Color::clear());
+            scroll_view.add_subview(content_view);
+            scroll_view.add_subview(vertical_scroll_bar.clone());
+            scroll_view.add_subview(horizontal_scroll_bar.clone());
 
             vertical_scroll_bar.fit_to_superview();
             horizontal_scroll_bar.fit_to_superview();
@@ -55,7 +55,7 @@ custom_view!(
                 gesture_recognizer.set_translation(Point::new(0, 0), &view);
             });
 
-            scroll_view.view.add_gesture_recognizer(Box::new(pan_gesture));
+            scroll_view.add_gesture_recognizer(Box::new(pan_gesture));
 
             scroll_view
         }
@@ -74,10 +74,10 @@ custom_view!(
 
         fn set_content_offset(&self, offset: Point<i32>) {
             let mut content_width = self.content_size().width;
-            let scrollview_width = self.view.frame().size.width;
+            let scrollview_width = self.frame().size.width;
 
             let mut content_height = self.content_size().height;
-            let scrollview_height = self.view.frame().size.height;
+            let scrollview_height = self.frame().size.height;
 
             if content_width < scrollview_width {
                 content_width = scrollview_width;
@@ -97,8 +97,8 @@ custom_view!(
                 Rectangle::new(
                     x,
                     y,
-                    self.view.bounds().size.width,
-                    self.view.bounds().size.height
+                    self.bounds().size.width,
+                    self.bounds().size.height
                 )
             );
 
@@ -110,12 +110,13 @@ custom_view!(
         }
 
         fn inner_content_view(&self) -> View {
-            self.view.subviews().get(0).expect("scroll view missing content subview").clone()
+            self.subviews().get(0).expect("scroll view missing content subview").clone()
         }
 
         /// Set (or replace) the current content view. This is the view that
         /// will actually be scrollable.
-        pub fn set_content_view(&self, view: View) {
+        pub fn set_content_view(&self, view: impl Into<View>) {
+            let view: View = view.into();
             if let Some(existing_subview) = self.inner_content_view().subviews().get(0) {
                 existing_subview.remove_from_superview();
             }
@@ -135,12 +136,12 @@ custom_view!(
         }
 
         fn vertical_scroll_bar(&self) -> ScrollBarView {
-            let view = self.view.subviews().get(1).expect("scroll view missing vertical scroll bar").clone();
+            let view = self.subviews().get(1).expect("scroll view missing vertical scroll bar").clone();
             ScrollBarView::from_view(view)
         }
 
         fn horizontal_scroll_bar(&self) -> ScrollBarView {
-            let view = self.view.subviews().get(2).expect("scroll view missing horizontal scroll bar").clone();
+            let view = self.subviews().get(2).expect("scroll view missing horizontal scroll bar").clone();
             ScrollBarView::from_view(view)
         }
 
@@ -150,7 +151,7 @@ custom_view!(
 
             // set_frame resets bounds.size to frame.size. Restore viewport-
             // sized bounds so the clips_to_bounds layer stays viewport-sized.
-            let viewport_size = self.view.frame().size.clone();
+            let viewport_size = self.frame().size.clone();
             inner_content_view.set_bounds(Rectangle::new(
                 0, 0,
                 viewport_size.width,
@@ -183,8 +184,8 @@ custom_view!(
             handle.set_background_color(Color::new(127, 127, 127, 127));
 
             let scroll_bar_view = Self::new_all(Rectangle::new(0, 0, 10, 10), direction, Cell::new(0));
-            scroll_bar_view.view.set_background_color(Color::clear());
-            scroll_bar_view.view.add_subview(handle);
+            scroll_bar_view.set_background_color(Color::clear());
+            scroll_bar_view.add_subview(handle);
 
             scroll_bar_view
         }
@@ -201,7 +202,7 @@ custom_view!(
         }
 
         fn handle(&self) -> View {
-            self.view.subviews().get(0).expect("scroll view missing content subview").clone()
+            self.subviews().get(0).expect("scroll view missing content subview").clone()
         }
 
         fn direction(&self) -> ScrollBarDirection {
@@ -210,7 +211,7 @@ custom_view!(
         }
 
         fn fit_to_superview(&self) {
-            let superview = self.view.superview().upgrade().expect("scroll view missing superview");
+            let superview = self.superview().upgrade().expect("scroll view missing superview");
             let superview_size = superview.frame().size;
             let frame: Rectangle<i32, u32>;
 
@@ -233,11 +234,11 @@ custom_view!(
                 }
             }
 
-            self.view.set_frame(frame);
+            self.set_frame(frame);
         }
 
         fn update_scroll_handle(&self) {
-            let superview = self.view.superview().upgrade().expect("scroll view missing superview");
+            let superview = self.superview().upgrade().expect("scroll view missing superview");
             let scrollview = ScrollView::from_view(superview);
             let inner_content_view = scrollview.inner_content_view();
             let handle = self.handle();
@@ -245,7 +246,7 @@ custom_view!(
             handle.set_hidden(true);
 
             let content_view_size = inner_content_view.frame().size;
-            let scrollview_size = scrollview.view.frame().size;
+            let scrollview_size = scrollview.frame().size;
 
             match self.direction() {
                 ScrollBarDirection::Vertical => {
@@ -324,7 +325,7 @@ mod tests {
         let scroll_view = ScrollView::new(Rectangle::new(0, 0, 100, 100));
 
         assert_eq!(
-            scroll_view.vertical_scroll_bar().view.frame().size,
+            scroll_view.vertical_scroll_bar().frame().size,
             Size::new(10, 100)
         );
 
@@ -339,7 +340,7 @@ mod tests {
         let scroll_view = ScrollView::new(Rectangle::new(0, 0, 100, 100));
 
         assert_eq!(
-            scroll_view.horizontal_scroll_bar().view.frame().size,
+            scroll_view.horizontal_scroll_bar().frame().size,
             Size::new(100, 10)
         );
 

--- a/src/ui/view/text_field.rs
+++ b/src/ui/view/text_field.rs
@@ -128,8 +128,8 @@ custom_view!(
                 frame.height() - (LABEL_PADDING * 2)
             );
             let label = Label::new(label_frame, text);
-            label.view.set_tag(1);
-            label.view.set_user_interaction_enabled(false);
+            label.set_tag(1);
+            label.set_user_interaction_enabled(false);
 
             let carats = RefCell::new(Vec::new());
             let text_field = TextField::new_all(
@@ -146,10 +146,10 @@ custom_view!(
                 RefCell::new(None)
             );
 
-            text_field.view.add_subview(label.view);
+            text_field.add_subview(label);
             text_field.spawn_carat(0);
 
-            let weak_text_field = text_field.view.downgrade();
+            let weak_text_field = text_field.downgrade();
             let carat_animation_timer = Timer::new_repeating(Duration::from_millis(CARAT_BLINK_INTERVAL_MS), move || {
                 if let Some(view) = weak_text_field.upgrade() {
                     let text_field = TextField::from_view(view);
@@ -171,14 +171,14 @@ custom_view!(
         }
 
         pub fn label(&self) -> Label {
-            let view = self.view.view_with_tag(1).expect("label subview was not found");
+            let view = self.view_with_tag(1).expect("label subview was not found");
             Label::from_view(view)
         }
 
         fn touch_to_index(&self, touch: &Touch) -> usize {
             let window = touch.window().expect("touch had no associated window");
             let label = self.label();
-            let position = window.view.convert_point_to(&touch.position(), &label.view);
+            let position = window.convert_point_to(&touch.position(), &label);
             let label_behavior = label.behavior();
             let rendering = label_behavior.rendering();
             let render_scale = rendering.render_scale();
@@ -239,7 +239,7 @@ custom_view!(
                 carat_view.set_background_color(CARAT_COLOR);
                 carat_view.set_hidden(true);
                 carat_view.set_user_interaction_enabled(false);
-                self.view.add_subview(carat_view.clone());
+                self.add_subview(carat_view.clone());
 
                 let carat = Carat {
                     view: carat_view.downgrade(),
@@ -250,7 +250,7 @@ custom_view!(
                 carats.push(carat);
             }
             self.consume_and_sort_cursors();
-            self.view.set_needs_display();
+            self.set_needs_display();
         }
 
         fn animate_carats(&self) {
@@ -480,7 +480,7 @@ custom_view!(
 
             for carat in carats.iter() {
                 let character_index = carat.character_index.get();
-                let label_origin = &self.label().view.frame().origin;
+                let label_origin = &self.label().frame().origin;
                 let carat_view = carat.view.upgrade().expect("carat view was deallocated");
                 let cursor_rectangle = rendering.cursor_rectangle_for_character_at_index(character_index);
 
@@ -571,7 +571,7 @@ custom_view!(
 
             selection.views.borrow_mut().clear();
 
-            let label_origin = &self.label().view.frame().origin;
+            let label_origin = &self.label().frame().origin;
 
             let mut character_index = selection.start;
             let mut last_y = -9999999;
@@ -588,7 +588,7 @@ custom_view!(
                     last_y = cursor_rectangle.origin.y;
                     current_view = View::new(Rectangle::new(0, 0, 1, 1));
                     current_view.set_user_interaction_enabled(false);
-                    self.view.add_subview(current_view.clone());
+                    self.add_subview(current_view.clone());
                     current_view.set_frame(Rectangle {
                         origin: Point {
                             x: (cursor_rectangle.origin.x as f32 / render_scale).round() as i32 + label_origin.x,

--- a/src/ui/view/view.rs
+++ b/src/ui/view/view.rs
@@ -127,7 +127,8 @@ impl View {
     /// Adds a child `View` to this `View`.
     ///
     /// Also sets the parent (`superview`) of the child view to this `View`.
-    pub fn add_subview(&self, child: View) {
+    pub fn add_subview(&self, child: impl Into<View>) {
+        let child: View = child.into();
         let weak_self = self.downgrade();
         let mut inner_self = self.inner_self.borrow_mut();
 


### PR DESCRIPTION
## Summary
- Adds `Deref<Target=View>` and `From<Widget> for View` to the `custom_view!` macro, so all widgets (Label, Button, ScrollView, etc.) can be used directly where a `View` is expected — no more `.view` field access needed.
- Changes `View::add_subview` to accept `impl Into<View>`, allowing `view.add_subview(button)` instead of `view.add_subview(button.view)`.
- Adds `AttributedString::set_attribute(range, attribute)` for ergonomic range-based attribute setting, plus `Attribute::key()` to infer the key from the variant.
- Updates all callsites across src and examples.

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` — all 195 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)