### PR TITLE
Add WebView widget with SDL2/native focus coordination

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,9 @@ name = "text_field"
 [[example]]
 name = "pan_gesture"
 
+[[example]]
+name = "webview"
+
 [[test]]
 name = "main_thread_tests"
 path = "main_thread_tests/main.rs"

--- a/examples/webview.rs
+++ b/examples/webview.rs
@@ -1,0 +1,69 @@
+use pelican::graphics::Rectangle;
+use pelican::ui::{View, Window, Color, WebView, TextField};
+use pelican::ui::{ApplicationMain, ApplicationDelegate};
+use pelican::ui::{ViewController, ViewControllerBehavior};
+
+const URL_BAR_HEIGHT: u32 = 45;
+const PADDING: u32 = 4;
+const WINDOW_WIDTH: u32 = 800;
+const WINDOW_HEIGHT: u32 = 600;
+
+struct ExampleViewController {}
+impl ViewControllerBehavior for ExampleViewController {
+    fn view_did_load(&self, view: View) {
+        view.set_background_color(Color::new(48, 48, 48, 255));
+
+        // URL bar
+        let url_bar = TextField::new(
+            Rectangle::new(
+                PADDING as i32,
+                PADDING as i32,
+                WINDOW_WIDTH - (PADDING * 2),
+                URL_BAR_HEIGHT,
+            ),
+            String::from("https://example.com"),
+        );
+        url_bar.set_background_color(Color::white());
+
+        // WebView below the URL bar
+        let web_view = WebView::new(Rectangle::new(
+            PADDING as i32,
+            (URL_BAR_HEIGHT + PADDING * 2) as i32,
+            WINDOW_WIDTH - (PADDING * 2),
+            WINDOW_HEIGHT - URL_BAR_HEIGHT - (PADDING * 3),
+        ));
+        web_view.load_url("https://example.com");
+
+        view.add_subview(url_bar.clone());
+        view.add_subview(web_view.clone());
+
+        // Navigate when Return is pressed (inserts \n into text)
+        url_bar.on_text_change(move |text_field| {
+            let text = text_field.label().text().to_string();
+            if text.contains('\n') {
+                let mut url = text.trim().replace('\n', "");
+                if !url.starts_with("http://") && !url.starts_with("https://") {
+                    url = format!("https://{}", url);
+                }
+                text_field.label().set_text(url.clone());
+                web_view.load_url(&url);
+            }
+        });
+    }
+}
+
+struct AppDelegate {}
+impl ApplicationDelegate for AppDelegate {
+    fn application_did_finish_launching(&self) {
+        let frame = Rectangle::new(100, 100, WINDOW_WIDTH, WINDOW_HEIGHT);
+        let view_controller = ViewController::new(ExampleViewController {});
+        let window = Window::new("Mini Browser", frame, view_controller);
+        window.make_key_and_visible();
+    }
+}
+
+pub fn main() -> Result<(), String> {
+    let application_main = ApplicationMain::new(AppDelegate {});
+    application_main.launch();
+    Ok(())
+}

--- a/examples/webview.rs
+++ b/examples/webview.rs
@@ -21,7 +21,7 @@ impl ViewControllerBehavior for ExampleViewController {
                 WINDOW_WIDTH - (PADDING * 2),
                 URL_BAR_HEIGHT,
             ),
-            String::from("https://example.com"),
+            String::from("https://google.com"),
         );
         url_bar.set_background_color(Color::white());
 
@@ -32,7 +32,7 @@ impl ViewControllerBehavior for ExampleViewController {
             WINDOW_WIDTH - (PADDING * 2),
             WINDOW_HEIGHT - URL_BAR_HEIGHT - (PADDING * 3),
         ));
-        web_view.load_url("https://example.com");
+        web_view.load_url("https://google.com");
 
         view.add_subview(url_bar.clone());
         view.add_subview(web_view.clone());

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -165,6 +165,39 @@ impl Context {
             canvas.clear();
         }).expect("failed to clear texture");
     }
+
+    #[cfg(target_os = "macos")]
+    pub fn ns_content_view(&self) -> Option<std::ptr::NonNull<std::ffi::c_void>> {
+        use sdl2::raw_window_handle::{SDL_SysWMinfo, SDL_bool};
+        use objc::runtime::Object;
+        use objc::{msg_send, sel, sel_impl};
+
+        extern "C" {
+            fn SDL_GetWindowWMInfo(
+                window: *mut sdl2::sys::SDL_Window,
+                info: *mut SDL_SysWMinfo,
+            ) -> SDL_bool;
+        }
+
+        let canvas = self.inner.canvas.borrow();
+        let raw_window = canvas.window().raw();
+
+        let mut wm_info: SDL_SysWMinfo = unsafe { std::mem::zeroed() };
+        unsafe {
+            sdl2::sys::SDL_GetVersion(&mut wm_info.version);
+            if SDL_GetWindowWMInfo(raw_window, &mut wm_info) == SDL_bool::SDL_FALSE {
+                return None;
+            }
+        }
+
+        let ns_window = unsafe { wm_info.info.cocoa }.window;
+        if ns_window.is_null() {
+            return None;
+        }
+
+        let ns_view: *mut Object = unsafe { msg_send![ns_window as *mut Object, contentView] };
+        std::ptr::NonNull::new(ns_view as *mut std::ffi::c_void)
+    }
 }
 
 impl Clone for Context {

--- a/src/ui/event_loop.rs
+++ b/src/ui/event_loop.rs
@@ -103,7 +103,9 @@ pub(crate) fn update() {
                 let window = application.get_window(window_id);
                 if let Some(window) = window {
                     let first_responder = window.first_responder();
-                    first_responder.text_input_did_receive(&text);
+                    if !first_responder.handles_native_keyboard_input() {
+                        first_responder.text_input_did_receive(&text);
+                    }
                 }
             },
 
@@ -165,8 +167,10 @@ pub(crate) fn update() {
                     let press = event.press();
                     if let Some(window) = window {
                         let first_responder = window.first_responder();
-                        press.set_first_responder(first_responder.downgrade());
-                        first_responder.press_began(press, &event);
+                        if !first_responder.handles_native_keyboard_input() {
+                            press.set_first_responder(first_responder.downgrade());
+                            first_responder.press_began(press, &event);
+                        }
                     }
                 }
             },

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -24,6 +24,8 @@ pub use view_controller::ViewControllerBehavior;
 pub use view_controller::ViewController;
 pub use view::ScrollView;
 pub use view::TextField;
+#[cfg(target_os = "macos")]
+pub use view::WebView;
 
 pub mod gesture;
 

--- a/src/ui/view/behavior.rs
+++ b/src/ui/view/behavior.rs
@@ -102,6 +102,8 @@ pub trait Behavior {
     /// Called when this view becomes the first responder.
     fn did_become_first_responder(&self) {}
 
+
+
     fn next_responder(&self) -> Option<Rc<RefCell<Box<dyn Behavior>>>> {
         if let Some(super_behavior) = self.super_behavior() {
             super_behavior.next_responder()

--- a/src/ui/view/behavior.rs
+++ b/src/ui/view/behavior.rs
@@ -88,6 +88,20 @@ pub trait Behavior {
         }
     }
 
+    /// Returns `true` if this view handles keyboard input natively (outside
+    /// of SDL2). When the first responder returns `true`, the event loop will
+    /// skip forwarding `TextInput` and `KeyDown` events through SDL2 to avoid
+    /// double input.
+    fn handles_native_keyboard_input(&self) -> bool {
+        false
+    }
+
+    /// Called when this view is no longer the first responder.
+    fn did_resign_first_responder(&self) {}
+
+    /// Called when this view becomes the first responder.
+    fn did_become_first_responder(&self) {}
+
     fn next_responder(&self) -> Option<Rc<RefCell<Box<dyn Behavior>>>> {
         if let Some(super_behavior) = self.super_behavior() {
             super_behavior.next_responder()

--- a/src/ui/view/mod.rs
+++ b/src/ui/view/mod.rs
@@ -7,6 +7,8 @@ pub mod image_view;
 pub mod label;
 pub mod scroll_view;
 pub mod text_field;
+#[cfg(target_os = "macos")]
+pub mod web_view;
 
 pub use view::View;
 pub use weak_view::WeakView;
@@ -17,6 +19,8 @@ pub use image_view::ImageView;
 pub use label::Label;
 pub use scroll_view::ScrollView;
 pub use text_field::TextField;
+#[cfg(target_os = "macos")]
+pub use web_view::WebView;
 
 #[cfg(test)]
 mod tests {

--- a/src/ui/view/text_field.rs
+++ b/src/ui/view/text_field.rs
@@ -702,6 +702,7 @@ custom_view!(
 
         fn touches_began(&self, touches: &Vec<Touch>) {
             let view = self.view.upgrade().expect("view was deallocated");
+            view.become_first_responder();
             let text_field = TextField::from_view(view.clone());
 
             let touched_character_index = text_field.touch_to_index(touches.first().expect("touches list was empty"));

--- a/src/ui/view/text_field.rs
+++ b/src/ui/view/text_field.rs
@@ -771,6 +771,11 @@ custom_view!(
             self.last_click.set(Instant::now());
         }
 
+        fn did_become_first_responder(&self) {
+            // Ensure SDL2 text input is active so we receive TextInput events.
+            unsafe { sdl2::sys::SDL_StartTextInput(); }
+        }
+
         fn text_input_did_receive(&self, text: &str) {
             let view = self.view.upgrade().expect("view was deallocated");
             let text_field = TextField::from_view(view.clone());

--- a/src/ui/view/view.rs
+++ b/src/ui/view/view.rs
@@ -268,8 +268,8 @@ impl View {
         let inner_self = self.inner_self.borrow();
         let superview = inner_self.superview.upgrade();
 
-        if superview.is_none() {
-            return inner_self.frame.origin.clone();
+        if superview.is_none() || self.is_window() {
+            return Point { x: 0, y: 0 };
         }
 
         let superview = superview.expect("superview was checked but missing");
@@ -480,6 +480,8 @@ impl View {
         let behavior = self.behavior.borrow();
         behavior.did_become_first_responder();
     }
+
+
 }
 
 impl LayerDelegate for View {

--- a/src/ui/view/view.rs
+++ b/src/ui/view/view.rs
@@ -465,6 +465,21 @@ impl View {
         let behavior = self.behavior.borrow();
         behavior.text_input_did_receive(text);
     }
+
+    pub fn handles_native_keyboard_input(&self) -> bool {
+        let behavior = self.behavior.borrow();
+        behavior.handles_native_keyboard_input()
+    }
+
+    pub(crate) fn did_resign_first_responder(&self) {
+        let behavior = self.behavior.borrow();
+        behavior.did_resign_first_responder();
+    }
+
+    pub(crate) fn did_become_first_responder(&self) {
+        let behavior = self.behavior.borrow();
+        behavior.did_become_first_responder();
+    }
 }
 
 impl LayerDelegate for View {

--- a/src/ui/view/web_view.rs
+++ b/src/ui/view/web_view.rs
@@ -9,6 +9,7 @@ use wry::WebViewBuilder;
 use std::ptr::NonNull;
 use std::ffi::c_void;
 use std::cell::{RefCell, Cell};
+
 struct NsContentViewParent {
     ns_view: NonNull<c_void>,
 }
@@ -170,9 +171,6 @@ custom_view!(
             let behavior = self.behavior();
             let wry = behavior.wry_webview.borrow();
             if let Some(webview) = wry.as_ref() {
-                // Stop SDL2 text input so it doesn't intercept/duplicate key
-                // events that the native WKWebView should handle exclusively.
-                unsafe { sdl2::sys::SDL_StopTextInput(); }
                 let _ = webview.focus();
             }
             behavior.focused.set(true);
@@ -183,8 +181,6 @@ custom_view!(
             let wry = behavior.wry_webview.borrow();
             if let Some(webview) = wry.as_ref() {
                 let _ = webview.focus_parent();
-                // Restart SDL2 text input so Houston views can receive text again.
-                unsafe { sdl2::sys::SDL_StartTextInput(); }
             }
             behavior.focused.set(false);
         }
@@ -235,6 +231,9 @@ custom_view!(
         }
 
         fn did_become_first_responder(&self) {
+            // Stop SDL2 text input so it doesn't intercept/duplicate key
+            // events that the native WKWebView should handle exclusively.
+            unsafe { sdl2::sys::SDL_StopTextInput(); }
             let view_type = self.view_type();
             view_type.native_focus();
         }

--- a/src/ui/view/web_view.rs
+++ b/src/ui/view/web_view.rs
@@ -1,0 +1,242 @@
+use crate::graphics::Rectangle;
+use crate::ui::view::DefaultBehavior;
+use crate::ui::window::Window;
+use crate::ui::Color;
+use crate::ui::Touch;
+use crate::macros::*;
+use wry::raw_window_handle::{AppKitWindowHandle, HandleError, HasWindowHandle, RawWindowHandle, WindowHandle};
+use wry::WebViewBuilder;
+use std::ptr::NonNull;
+use std::ffi::c_void;
+use std::cell::{RefCell, Cell};
+struct NsContentViewParent {
+    ns_view: NonNull<c_void>,
+}
+
+impl HasWindowHandle for NsContentViewParent {
+    fn window_handle(&self) -> Result<WindowHandle<'_>, HandleError> {
+        let appkit = AppKitWindowHandle::new(self.ns_view);
+        let raw = RawWindowHandle::AppKit(appkit);
+        // SAFETY: we're creating a borrowed handle from a stable pointer
+        Ok(unsafe { WindowHandle::borrow_raw(raw) })
+    }
+}
+
+pub(crate) enum WebViewContent {
+    Url(String),
+    Html(String),
+}
+
+custom_view!(
+    WebView subclasses DefaultBehavior
+
+    struct WebViewBehavior {
+        wry_webview: RefCell<Option<wry::WebView>>,
+        pending_content: RefCell<Option<WebViewContent>>,
+        focused: Cell<bool>
+    }
+
+    impl Self {
+        pub fn new(frame: Rectangle<i32, u32>) -> Self {
+            let web_view = Self::new_all(
+                frame,
+                RefCell::new(None),
+                RefCell::new(None),
+                Cell::new(false),
+            );
+            web_view.set_background_color(Color::clear());
+            web_view
+        }
+
+        pub fn load_url(&self, url: &str) {
+            let behavior = self.behavior();
+            let wry = behavior.wry_webview.borrow();
+            if let Some(webview) = wry.as_ref() {
+                let _ = webview.load_url(url);
+            } else {
+                drop(wry);
+                behavior.pending_content.replace(Some(WebViewContent::Url(url.to_string())));
+                self.set_needs_display();
+            }
+        }
+
+        pub fn load_html(&self, html: &str) {
+            let behavior = self.behavior();
+            let wry = behavior.wry_webview.borrow();
+            if let Some(webview) = wry.as_ref() {
+                let _ = webview.load_html(html);
+            } else {
+                drop(wry);
+                behavior.pending_content.replace(Some(WebViewContent::Html(html.to_string())));
+                self.set_needs_display();
+            }
+        }
+
+        fn find_window(&self) -> Option<Window> {
+            let mut current_view = self.view.clone();
+            loop {
+                if current_view.is_window() {
+                    return Some(Window::from_view(current_view));
+                }
+                if let Some(superview) = current_view.superview().upgrade() {
+                    current_view = superview;
+                } else {
+                    return None;
+                }
+            }
+        }
+
+        fn ensure_webview(&self) -> bool {
+            {
+                let behavior = self.behavior();
+                if behavior.wry_webview.borrow().is_some() {
+                    return true;
+                }
+            }
+
+            let window = match self.find_window() {
+                Some(w) => w,
+                None => return false,
+            };
+
+            let ns_view = match window.context().ns_content_view() {
+                Some(v) => v,
+                None => return false,
+            };
+
+            let parent = NsContentViewParent { ns_view };
+
+            // Capture a WeakView so the IPC handler can call become_first_responder
+            // directly when the native webview is clicked.
+            let weak_view = self.view.downgrade();
+
+            let builder = WebViewBuilder::new()
+                .with_transparent(true)
+                .with_focused(false)
+                .with_initialization_script(
+                    "document.addEventListener('mousedown', function() { \
+                        window.ipc.postMessage('clicked'); \
+                    }, true);"
+                )
+                .with_ipc_handler(move |_req| {
+                    if let Some(view) = weak_view.upgrade() {
+                        view.become_first_responder();
+                    }
+                });
+
+            let webview = match builder.build_as_child(&parent) {
+                Ok(wv) => wv,
+                Err(_) => return false,
+            };
+
+            // Don't let the native webview steal focus on creation
+            let _ = webview.focus_parent();
+
+            let behavior = self.behavior();
+
+            // Load pending content
+            let pending = behavior.pending_content.borrow_mut().take();
+            match pending {
+                Some(WebViewContent::Url(url)) => { let _ = webview.load_url(&url); }
+                Some(WebViewContent::Html(html)) => { let _ = webview.load_html(&html); }
+                None => {}
+            }
+
+            behavior.wry_webview.borrow_mut().replace(webview);
+            true
+        }
+
+        fn sync_bounds(&self) {
+            let behavior = self.behavior();
+            let wry = behavior.wry_webview.borrow();
+            if let Some(webview) = wry.as_ref() {
+                let location = self.view.get_location_in_window();
+                let frame = self.view.frame();
+
+                let _ = webview.set_bounds(wry::Rect {
+                    position: dpi::Position::Logical(dpi::LogicalPosition {
+                        x: location.x as f64,
+                        y: location.y as f64,
+                    }),
+                    size: dpi::Size::Logical(dpi::LogicalSize {
+                        width: frame.size.width as f64,
+                        height: frame.size.height as f64,
+                    }),
+                });
+            }
+        }
+
+        fn native_focus(&self) {
+            let behavior = self.behavior();
+            let wry = behavior.wry_webview.borrow();
+            if let Some(webview) = wry.as_ref() {
+                // Stop SDL2 text input so it doesn't intercept/duplicate key
+                // events that the native WKWebView should handle exclusively.
+                unsafe { sdl2::sys::SDL_StopTextInput(); }
+                let _ = webview.focus();
+            }
+            behavior.focused.set(true);
+        }
+
+        fn native_blur(&self) {
+            let behavior = self.behavior();
+            let wry = behavior.wry_webview.borrow();
+            if let Some(webview) = wry.as_ref() {
+                let _ = webview.focus_parent();
+                // Restart SDL2 text input so Houston views can receive text again.
+                unsafe { sdl2::sys::SDL_StartTextInput(); }
+            }
+            behavior.focused.set(false);
+        }
+
+        fn sync_focus_state(&self) {
+            let is_focused = self.behavior().focused.get();
+
+            if let Some(window) = self.find_window() {
+                let first_responder = window.first_responder();
+                let we_are_first_responder = first_responder.id() == self.view.id();
+
+                if we_are_first_responder && !is_focused {
+                    self.native_focus();
+                } else if !we_are_first_responder && is_focused {
+                    self.native_blur();
+                }
+            }
+        }
+    }
+
+    impl Behavior {
+        fn draw(&self) {
+            let view_type = self.view_type();
+            view_type.ensure_webview();
+            view_type.sync_bounds();
+            view_type.sync_focus_state();
+
+            // Clear the layer to transparent so the native webview shows through
+            let view = self.view.upgrade().expect("view was deallocated");
+            let inner_self = view.inner_self.borrow();
+            if let Some(layer) = &inner_self.layer {
+                layer.clear_with_color(sdl2::pixels::Color::RGBA(0, 0, 0, 0));
+            }
+        }
+
+        fn touches_began(&self, _touches: &Vec<Touch>) {
+            let view = self.view.upgrade().expect("view was deallocated");
+            view.become_first_responder();
+        }
+
+        fn handles_native_keyboard_input(&self) -> bool {
+            true
+        }
+
+        fn did_resign_first_responder(&self) {
+            let view_type = self.view_type();
+            view_type.native_blur();
+        }
+
+        fn did_become_first_responder(&self) {
+            let view_type = self.view_type();
+            view_type.native_focus();
+        }
+    }
+);

--- a/src/ui/window.rs
+++ b/src/ui/window.rs
@@ -111,15 +111,23 @@ impl Window {
     }
 
     pub(crate) fn replace_first_responder(&self, view: View) -> bool {
+        let old_responder = self.first_responder();
+
         // If there is a first responder, ask whether it wants to resign. If it
         // doesn't, then we can't replace it.
-        if !self.first_responder().can_resign_first_responder() {
+        if !old_responder.can_resign_first_responder() {
             return false;
         }
 
         let behavior = self.view.behavior.borrow();
         let behavior = behavior.as_any().downcast_ref::<WindowBehavior>().expect("view is not a Window");
         behavior.first_responder.replace(view.downgrade());
+
+        if old_responder.id() != view.id() {
+            old_responder.did_resign_first_responder();
+            view.did_become_first_responder();
+        }
+
         return true;
     }
 }


### PR DESCRIPTION
## Summary

- Adds a `WebView` widget backed by wry/WKWebView, integrated into the Pelican view hierarchy with proper focus coordination between SDL2 and native macOS views
- Manages first responder handoff: clicking the webview (detected via IPC) claims focus and stops SDL2 text input; clicking a TextField reclaims it and restarts SDL2 text input
- Adds `did_become_first_responder` / `did_resign_first_responder` hooks to the Behavior trait, called from `Window::replace_first_responder`
- Adds `handles_native_keyboard_input()` to suppress SDL2 keyboard event forwarding when a native view has focus
- Includes a mini browser example (`examples/webview.rs`) with a URL bar and webview

## Known limitations

- Cmd+key shortcuts (Cmd+A, Cmd+C, etc.) don't work in the webview for some reason

## Test plan

- [ ] `cargo run --example webview` — verify page loads, URL bar accepts text, clicking webview takes focus, clicking URL bar reclaims it
- [ ] `cargo run --example text_field` — verify no regressions in text field behavior
- [ ] Verify no double character input when typing in either the URL bar or webview search fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)